### PR TITLE
#152129025 initialize carousel after data load

### DIFF
--- a/src/public/js/controllers/index.js
+++ b/src/public/js/controllers/index.js
@@ -1,11 +1,37 @@
 angular.module('mean.system')
   .controller('IndexController', ['$scope', 'Global', '$cookieStore', '$cookies', '$location', '$http', '$window', 'socket', 'game', 'AvatarService', function ($scope, Global, $cookieStore, $cookies, $location, $http, $window, socket, game, AvatarService) {
 
+    $scope.donors = [];
+
     $scope.scrollTo = function (id) {
       // Scroll
     $('html,body').animate({
         scrollTop: $(`#${id}`).offset().top}, 'slow');
     }
+
+    $http.get('/api/donors')
+    .then((res) => {
+      const donors = res.data;
+      for (let i=0; i < donors.length; i++) {
+        donorsDonations = donors[i].donations;
+        for (let i=0; i < donorsDonations.length; i++) {
+          if (donorsDonations[i].donor_consent === true) {
+            $scope.donors.push(donorsDonations[i])
+          }
+        }
+      }
+      if ($scope.donors.length > 0) {
+        $(document).ready(function () {
+          $('.carousel').carousel('destroy');
+          $('.carousel').carousel();
+          autoplay()
+          function autoplay() {
+              $('.carousel').carousel('next');
+              setTimeout(autoplay, 4000);
+          }
+        });
+      }
+    });
 
     $scope.seekConsent = () => {
       return swal({

--- a/src/public/js/controllers/index.js
+++ b/src/public/js/controllers/index.js
@@ -11,15 +11,9 @@ angular.module('mean.system')
 
     $http.get('/api/donors')
     .then((res) => {
-      const donors = res.data;
-      for (let i=0; i < donors.length; i++) {
-        donorsDonations = donors[i].donations;
-        for (let i=0; i < donorsDonations.length; i++) {
-          if (donorsDonations[i].donor_consent === true) {
-            $scope.donors.push(donorsDonations[i])
-          }
-        }
-      }
+      console.log(res, 'responses');
+      const data = res.data.reduce((acc, val) => acc.concat(val.donations), []);
+      $scope.donors = data.filter((val) => val.donor_consent === "true");
       if ($scope.donors.length > 0) {
         $(document).ready(function () {
           $('.carousel').carousel('destroy');

--- a/src/public/js/controllers/index.js
+++ b/src/public/js/controllers/index.js
@@ -11,7 +11,6 @@ angular.module('mean.system')
 
     $http.get('/api/donors')
     .then((res) => {
-      console.log(res, 'responses');
       const data = res.data.reduce((acc, val) => acc.concat(val.donations), []);
       $scope.donors = data.filter((val) => val.donor_consent === "true");
       if ($scope.donors.length > 0) {

--- a/src/public/js/controllers/log.js
+++ b/src/public/js/controllers/log.js
@@ -10,7 +10,6 @@ angular.module('mean.system')
   $scope.mags = [];
   $scope.gameRank = [];
   $scope.donations = [];
-  $scope.donors = [];
   $scope.paginationCounters = [];
   $scope.leaderboardData = [];
 
@@ -54,20 +53,6 @@ angular.module('mean.system')
     for (let i = 0; i < donation.length; i += 1) {
       $scope.donations.push(donation[i]);
     }
-  });
-
-  $http.get('/api/donors')
-  .then((res) => {
-    const donors = res.data;
-    for (let i=0; i < donors.length; i++) {
-      donorsDonations = donors[i].donations;
-      for (let i=0; i < donorsDonations.length; i++) {
-        if (donorsDonations[i].donor_consent === true) {
-          $scope.donors.push(donorsDonations[i])
-        }
-      }
-    }
-    $scope.loadCarousel = true;
   });
 
   let pageNumber = 0

--- a/src/public/views/index.html
+++ b/src/public/views/index.html
@@ -160,7 +160,7 @@
       Nasirudeen Abdulrasaq</p>
     </div>
   
-  <div class='row' ng-show="donors.length > 0" ng-controller="LogController">
+  <div class='row' ng-show="donors.length > 0">
     <div class='col s12 m12 l12'>
         <h4 class="font-freckle-face mt-0 center-align">Oh Look! Our Awesome Donors</h4>
         <div class="carousel" data-indicators="true">


### PR DESCRIPTION
### What does this PR do?
Initialize carousel after data is loaded

### Description of Task to be completed?
Ensure that the carousel loads donors' name and amount donated if they give their positive consent

### How should this be manually tested?
- Pull in latest changes
- Install all dependencies after pulling `npm install` or `npm update`
- run `npm build` then run `npm start`
- Open up the application with the url provided and view donors consent on the homepage, just above the footer

### Any background context you want to provide?
There needs to be donation(s) made with positive donor consent, for carousel to show the data

### What are the relevant pivotal tracker stories?
#152129025 Initialize carousel after data is loaded

### Screenshots (if appropriate)
<img width="1437" alt="screen shot 2017-10-20 at 7 44 07 pm" src="https://user-images.githubusercontent.com/20375577/31836991-13659d3a-b5cf-11e7-8b9f-b0e0853c91d9.png">

### Questions:
N/A
