### PR TITLE
#152166072 Fix donors carousel to display on homepage

### DIFF
--- a/src/app/views/includes/foot.jade
+++ b/src/app/views/includes/foot.jade
@@ -16,9 +16,6 @@ script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/limon
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 <script src="/js/materialize.js"></script>
 
-// Carousel Slider script
-<script src="owl/owl.carousel.min.js"></script>
-
 //AngularJS
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular.js')
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-resource.js')

--- a/src/app/views/includes/head.jade
+++ b/src/app/views/includes/head.jade
@@ -42,8 +42,6 @@ head
   link(rel='stylesheet', href='/css/style.css')
   link(rel='stylesheet', href='/css/chat.css')
   link(rel='stylesheet', href='/css/dashboard-ui.css')
-  <link rel="stylesheet" href="owl/owl.carousel.min.css">
-  <link rel="stylesheet" href="owl/owl.theme.default.min.css">
   link(rel='stylesheet', href='/css/landing.css')
 
   <!-- Emoji Data -->

--- a/src/public/js/controllers/index.js
+++ b/src/public/js/controllers/index.js
@@ -12,7 +12,8 @@ angular.module('mean.system')
     $http.get('/api/donors')
     .then((res) => {
       const data = res.data.reduce((acc, val) => acc.concat(val.donations), []);
-      $scope.donors = data.filter((val) => val.donor_consent === "true");
+      $scope.donors = data.filter((val) => val.donor_consent === "true" || val.donor_consent === true);
+      console.log($scope.donors);
       if ($scope.donors.length > 0) {
         $(document).ready(function () {
           $('.carousel').carousel('destroy');

--- a/src/public/views/index.html
+++ b/src/public/views/index.html
@@ -335,14 +335,5 @@
 <script>
   $(document).ready(function () {
     $('.dropdown-button').dropdown();
-    setTimeout(function(){
-      $('.carousel').carousel();
-      autoplay()
-      function autoplay() {
-        $('.carousel').carousel('next');
-        setTimeout(autoplay, 4000);
-      }
-    }, 300);
   });
-  
 </script>


### PR DESCRIPTION
### What does this PR do?
- cleanup unneeded owl-carousel files, 
- checked for string `true` and bool true in `donor_consent` which is filtered to display in carousel

### Description of Task to be completed?
From the donors' data gotten from the database, ensure that the `donor_consent` field is checked against **string** type of `true` and **boolean** type of `true`

### How should this be manually tested?
- Pull in latest changes
- Install all dependencies after pulling npm install or npm update
- run npm build then run npm start
- Open up the application with the url provided and view donors carousel on the homepage, just above the footer

### Any background context you want to provide?
- Donations have to be made before the data can be displayed on the carousel

### What are the relevant pivotal tracker stories?
#152166072 Fix donors carousel to display on homepage

### Screenshots (if appropriate)
<img width="1437" alt="screen shot 2017-10-21 at 5 57 47 am" src="https://user-images.githubusercontent.com/20375577/31848210-d80bcea2-b624-11e7-89e2-cdd2c48822ce.png">

### Questions:
N/A
